### PR TITLE
Auto-focus text input when toggled with Command+\

### DIFF
--- a/src/features/ask/AskView.js
+++ b/src/features/ask/AskView.js
@@ -955,6 +955,16 @@ export class AskView extends LitElement {
     handleToggleTextInput() {
         this.showTextInput = !this.showTextInput;
         this.requestUpdate();
+        
+        // If we just showed the text input, focus it after the DOM updates
+        if (this.showTextInput) {
+            this.updateComplete.then(() => {
+                const textInput = this.shadowRoot?.getElementById('textInput');
+                if (textInput) {
+                    textInput.focus();
+                }
+            });
+        }
     }
 
     requestWindowResize(targetHeight) {


### PR DESCRIPTION
When the text input is shown via Command+\, it now automatically receives focus so users can start typing immediately without having to click the input field first.