### PR TITLE
Resolves an intermittent issue where the text input in the "Ask" window would not auto-focus on Windows

### DIFF
--- a/src/features/ask/AskView.js
+++ b/src/features/ask/AskView.js
@@ -754,12 +754,7 @@ export class AskView extends LitElement {
             ipcRenderer.on('window-blur', this.handleWindowBlur);
             ipcRenderer.on('window-did-show', () => {
                 if (!this.currentResponse && !this.isLoading && !this.isStreaming) {
-                    setTimeout(() => {
-                        const textInput = this.shadowRoot?.getElementById('textInput');
-                        if (textInput) {
-                            textInput.focus();
-                        }
-                    }, 100);
+                    this.focusTextInput();
                 }
             });
 
@@ -1180,6 +1175,19 @@ export class AskView extends LitElement {
         if (changedProperties.has('showTextInput') || changedProperties.has('isLoading')) {
             this.adjustWindowHeightThrottled();
         }
+
+        if (changedProperties.has('showTeextInput') && this.showTextInput) {
+            this.focusTextInput();
+        }
+    }
+
+    focusTextInput(){
+        requestAnimationFrame(() => {
+            const textInput = this.shadowRoot?.getElementById('textInput');
+            if (textInput){
+                textInput.focus();
+            }
+        });
     }
 
     firstUpdated() {


### PR DESCRIPTION
The previous implementation used a `setTimeout` to focus the text input, which led to a race condition where the focus would fail if the element wasn't fully rendered.

**_Changes Made:_**

1. Introduced `focusTextInput()` Method: A new method was added to `AskView.js` to centralize focus logic.
2. Used `requestAnimationFrame`: The new method uses `requestAnimationFrame()` to schedule the focus event, ensuring it only fires when the browser is ready for a repaint. This guarantees the element is visible and interactive, preventing the race condition.
3. Updated IPC Event Handler: The `window-did-show` event handler now calls the new `focusTextInput()` method directly, removing the unreliable `setTimeout`.

Fixes #40 