### PR TITLE
Enhance settings and network configuration with port configuration

### DIFF
--- a/pickleglass_web/app/settings/advanced/page.tsx
+++ b/pickleglass_web/app/settings/advanced/page.tsx
@@ -1,0 +1,299 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import { Settings, Wifi, Lock, Unlock } from 'lucide-react'
+import { useRedirectIfNotAuth } from '@/utils/auth'
+import { apiCall } from '@/utils/api'
+
+
+
+export default function AdvancedSettingsPage() {
+  const userInfo = useRedirectIfNotAuth()
+  const [isSaving, setIsSaving] = useState(false)
+  
+  // Advanced settings state
+  const [networkSettings, setNetworkSettings] = useState({
+    apiPort: null as number | null,
+    webPort: null as number | null,
+    lockPorts: false,
+    currentApiPort: null as number | null,
+    currentWebPort: null as number | null
+  })
+  const [isLoadingNetworkSettings, setIsLoadingNetworkSettings] = useState(false)
+
+  const fetchNetworkSettings = async () => {
+    try {
+      setIsLoadingNetworkSettings(true)
+      console.log('[Advanced Settings] Fetching network settings via API...')
+      const response = await apiCall('/api/network/settings', { method: 'GET' })
+      
+      if (!response.ok) {
+        throw new Error(`Failed to fetch network settings: ${response.status}`)
+      }
+      
+      const settings = await response.json()
+      console.log('[Advanced Settings] Retrieved network settings:', settings)
+      setNetworkSettings(settings)
+    } catch (error) {
+      console.error("Failed to fetch network settings:", error)
+    } finally {
+      setIsLoadingNetworkSettings(false)
+    }
+  }
+
+  useEffect(() => {
+    if (!userInfo) return
+    fetchNetworkSettings()
+  }, [userInfo])
+
+  const handleSaveNetworkSettings = async () => {
+    setIsSaving(true)
+    try {
+      console.log('[Advanced Settings] Saving network settings via API:', networkSettings)
+      const response = await apiCall('/api/network/settings', { 
+        method: 'POST',
+        body: JSON.stringify(networkSettings)
+      })
+      
+      if (!response.ok) {
+        const errorData = await response.json()
+        throw new Error(errorData.message || `Failed to save network settings: ${response.status}`)
+      }
+      
+      const result = await response.json()
+      console.log('[Advanced Settings] Network settings saved:', result)
+      await fetchNetworkSettings() // Refresh to get updated current ports
+    } catch (error) {
+      console.error("Failed to save network settings:", error)
+      alert(error instanceof Error ? error.message : "Failed to save network settings")
+    } finally {
+      setIsSaving(false)
+    }
+  }
+
+  const handleLockCurrentPorts = async () => {
+    setIsSaving(true)
+    try {
+      console.log('[Advanced Settings] Locking current ports via API...')
+      const response = await apiCall('/api/network/lock-ports', { method: 'POST' })
+      
+      if (!response.ok) {
+        const errorData = await response.json()
+        throw new Error(errorData.message || `Failed to lock current ports: ${response.status}`)
+      }
+      
+      const result = await response.json()
+      console.log('[Advanced Settings] Current ports locked:', result)
+      await fetchNetworkSettings() // Refresh settings
+    } catch (error) {
+      console.error("Failed to lock current ports:", error)
+      alert(error instanceof Error ? error.message : "Failed to lock current ports")
+    } finally {
+      setIsSaving(false)
+    }
+  }
+
+  const handleUnlockPorts = async () => {
+    setNetworkSettings(prev => ({
+      ...prev,
+      lockPorts: false,
+      apiPort: null,
+      webPort: null
+    }))
+  }
+
+  if (!userInfo) {
+    return (
+      <div className="min-h-screen bg-gray-50 flex items-center justify-center">
+        <div className="text-center">
+          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-gray-600 mx-auto"></div>
+          <p className="mt-4 text-gray-600">Loading...</p>
+        </div>
+      </div>
+    )
+  }
+
+  const tabs = [
+    { id: 'profile', name: 'Personal Profile', href: '/settings' },
+    { id: 'privacy', name: 'Data & Privacy', href: '/settings/privacy' },
+    { id: 'billing', name: 'Billing', href: '/settings/billing' },
+    { id: 'advanced', name: 'Advanced', href: '/settings/advanced' },
+  ]
+
+  return (
+    <div className="bg-stone-50 min-h-screen">
+      <div className="px-8 py-8">
+        <div className="mb-6">
+          <p className="text-xs text-gray-500 mb-1">Settings</p>
+          <h1 className="text-3xl font-bold text-gray-900">Personal Settings</h1>
+        </div>
+        
+        <div className="mb-8">
+          <nav className="flex space-x-10">
+            {tabs.map((tab) => (
+              <a
+                key={tab.id}
+                href={tab.href}
+                className={`pb-4 px-2 border-b-2 font-medium text-sm transition-colors ${
+                  tab.id === 'advanced'
+                    ? 'border-gray-900 text-gray-900'
+                    : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'
+                }`}
+              >
+                {tab.name}
+              </a>
+            ))}
+          </nav>
+        </div>
+
+        <div className="space-y-8">
+          <div className="bg-blue-50 border border-blue-200 rounded-lg p-4">
+            <div className="flex items-center gap-2 mb-2">
+              <Settings className="h-5 w-5 text-blue-600" />
+              <h3 className="font-semibold text-blue-900">Advanced Settings</h3>
+            </div>
+            <p className="text-sm text-blue-700">
+              Configure advanced system settings. Changes may require application restart.
+            </p>
+          </div>
+
+          {/* Network Settings Section */}
+          <div className="bg-white border border-gray-200 rounded-lg p-6">
+            <div className="flex items-center gap-2 mb-4">
+              <Wifi className="h-5 w-5 text-gray-600" />
+              <h3 className="text-lg font-semibold text-gray-900">Network Settings</h3>
+            </div>
+            
+            {isLoadingNetworkSettings ? (
+              <div className="text-center py-4">
+                <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-gray-600 mx-auto"></div>
+                <p className="mt-2 text-sm text-gray-600">Loading network settings...</p>
+              </div>
+            ) : (
+              <div className="space-y-6">
+                {/* Current Port Status */}
+                <div className="bg-gray-50 rounded-lg p-4">
+                  <h4 className="font-medium text-gray-900 mb-2">Current Active Ports</h4>
+                  <div className="grid grid-cols-2 gap-4 text-sm">
+                                      <div>
+                    <span className="text-gray-600">API Port:</span>
+                    <span className="ml-2 font-mono font-medium">
+                      {networkSettings.currentApiPort ? networkSettings.currentApiPort : 'Auto-assigned'}
+                    </span>
+                  </div>
+                  <div>
+                    <span className="text-gray-600">Web Interface Port:</span>
+                    <span className="ml-2 font-mono font-medium">
+                      {networkSettings.currentWebPort ? networkSettings.currentWebPort : 'Auto-assigned'}
+                    </span>
+                  </div>
+                  </div>
+                </div>
+
+                {/* Port Configuration */}
+                <div className="space-y-4">
+                  <div className="flex items-center gap-2">
+                    <h4 className="font-medium text-gray-900">Port Configuration</h4>
+                    <button
+                      onClick={networkSettings.lockPorts ? handleUnlockPorts : handleLockCurrentPorts}
+                      className="flex items-center gap-1 px-3 py-1 text-sm bg-gray-100 hover:bg-gray-200 rounded-md transition-colors"
+                      disabled={isSaving}
+                    >
+                      {networkSettings.lockPorts ? (
+                        <>
+                          <Unlock className="h-4 w-4" />
+                          Unlock Ports
+                        </>
+                      ) : (
+                        <>
+                          <Lock className="h-4 w-4" />
+                          Lock Current Ports
+                        </>
+                      )}
+                    </button>
+                  </div>
+
+                  <div className="grid grid-cols-2 gap-4">
+                    <div>
+                      <label htmlFor="api-port" className="block text-sm font-medium text-gray-700 mb-1">
+                        API Port
+                      </label>
+                      <input
+                        type="number"
+                        id="api-port"
+                        min="1024"
+                        max="65535"
+                        value={networkSettings.apiPort || ''}
+                        onChange={(e) => setNetworkSettings(prev => ({
+                          ...prev,
+                          apiPort: e.target.value ? parseInt(e.target.value) : null
+                        }))}
+                        className="w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm"
+                        placeholder="Auto-assign"
+                        disabled={networkSettings.lockPorts}
+                      />
+                      <p className="text-xs text-gray-500 mt-1">
+                        Leave empty for auto-assignment
+                      </p>
+                    </div>
+
+                    <div>
+                      <label htmlFor="web-port" className="block text-sm font-medium text-gray-700 mb-1">
+                        Web Interface Port
+                      </label>
+                      <input
+                        type="number"
+                        id="web-port"
+                        min="1024"
+                        max="65535"
+                        value={networkSettings.webPort || ''}
+                        onChange={(e) => setNetworkSettings(prev => ({
+                          ...prev,
+                          webPort: e.target.value ? parseInt(e.target.value) : null
+                        }))}
+                        className="w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm"
+                        placeholder="Auto-assign"
+                        disabled={networkSettings.lockPorts}
+                      />
+                      <p className="text-xs text-gray-500 mt-1">
+                        Leave empty for auto-assignment
+                      </p>
+                    </div>
+                  </div>
+
+                  <div className="flex items-center gap-2">
+                    <input
+                      type="checkbox"
+                      id="lock-ports"
+                      checked={networkSettings.lockPorts}
+                      onChange={(e) => setNetworkSettings(prev => ({
+                        ...prev,
+                        lockPorts: e.target.checked
+                      }))}
+                      className="rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+                    />
+                    <label htmlFor="lock-ports" className="text-sm text-gray-700">
+                      Lock these port settings (prevent auto-assignment)
+                    </label>
+                  </div>
+                </div>
+
+                <div className="pt-4 border-t border-gray-200 flex justify-end">
+                  <button
+                    onClick={handleSaveNetworkSettings}
+                    disabled={isSaving}
+                    className="px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-gray-800 hover:bg-gray-900 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-900 disabled:opacity-50"
+                  >
+                    {isSaving ? 'Saving...' : 'Save Network Settings'}
+                  </button>
+                </div>
+              </div>
+            )}
+          </div>
+
+          {/* Future Settings Placeholder */}
+        </div>
+      </div>
+    </div>
+  )
+} 

--- a/pickleglass_web/app/settings/billing/page.tsx
+++ b/pickleglass_web/app/settings/billing/page.tsx
@@ -17,9 +17,10 @@ export default function BillingPage() {
   }
 
   const tabs = [
-    { id: 'profile', name: 'Personal profile', href: '/settings' },
-    { id: 'privacy', name: 'Data & privacy', href: '/settings/privacy' },
+    { id: 'profile', name: 'Personal Profile', href: '/settings' },
+    { id: 'privacy', name: 'Data & Privacy', href: '/settings/privacy' },
     { id: 'billing', name: 'Billing', href: '/settings/billing' },
+    { id: 'advanced', name: 'Advanced', href: '/settings/advanced' },
   ]
 
   return (

--- a/pickleglass_web/app/settings/page.tsx
+++ b/pickleglass_web/app/settings/page.tsx
@@ -17,10 +17,11 @@ import { useRouter } from 'next/navigation'
 declare global {
   interface Window {
     ipcRenderer?: any;
+    require?: any;
   }
 }
 
-type Tab = 'profile' | 'privacy' | 'billing'
+type Tab = 'profile' | 'privacy' | 'billing' | 'advanced'
 type BillingCycle = 'monthly' | 'annually'
 
 export default function SettingsPage() {
@@ -32,6 +33,9 @@ export default function SettingsPage() {
   const [apiKeyInput, setApiKeyInput] = useState('')
   const [isSaving, setIsSaving] = useState(false)
   const [displayNameInput, setDisplayNameInput] = useState('')
+  
+
+  
   const router = useRouter()
 
   const fetchApiKeyStatus = async () => {
@@ -58,16 +62,18 @@ export default function SettingsPage() {
     }
     fetchProfileData()
 
-    if (window.ipcRenderer) {
-      window.ipcRenderer.on('api-key-updated', () => {
+    if (window.require) {
+      const { ipcRenderer } = window.require('electron')
+      ipcRenderer.on('api-key-updated', () => {
         console.log('Received api-key-updated event from main process.');
         fetchApiKeyStatus();
       });
     }
 
     return () => {
-      if (window.ipcRenderer) {
-        window.ipcRenderer.removeAllListeners('api-key-updated');
+      if (window.require) {
+        const { ipcRenderer } = window.require('electron')
+        ipcRenderer.removeAllListeners('api-key-updated');
       }
     }
   }, [userInfo])
@@ -94,6 +100,7 @@ export default function SettingsPage() {
     { id: 'profile' as Tab, name: 'Personal Profile', href: '/settings' },
     { id: 'privacy' as Tab, name: 'Data & Privacy', href: '/settings/privacy' },
     { id: 'billing' as Tab, name: 'Billing', href: '/settings/billing' },
+    { id: 'advanced' as Tab, name: 'Advanced', href: '/settings/advanced' },
   ]
 
   const handleSaveApiKey = async () => {
@@ -102,8 +109,9 @@ export default function SettingsPage() {
       await saveApiKey(apiKeyInput)
       setHasApiKey(true)
       setApiKeyInput('')
-      if (window.ipcRenderer) {
-        window.ipcRenderer.invoke('save-api-key', apiKeyInput);
+      if (window.require) {
+        const { ipcRenderer } = window.require('electron')
+        ipcRenderer.invoke('save-api-key', apiKeyInput);
       }
     } catch (error) {
       console.error("Failed to save API key:", error)
@@ -147,6 +155,8 @@ export default function SettingsPage() {
       console.error("Logout failed:", error)
     }
   }
+
+
 
   const renderBillingContent = () => (
     <div className="space-y-8">

--- a/pickleglass_web/app/settings/privacy/page.tsx
+++ b/pickleglass_web/app/settings/privacy/page.tsx
@@ -18,9 +18,10 @@ export default function PrivacySettingsPage() {
   }
 
   const tabs = [
-    { id: 'profile', name: 'Personal profile', href: '/settings' },
-    { id: 'privacy', name: 'Data & privacy', href: '/settings/privacy' },
+    { id: 'profile', name: 'Personal Profile', href: '/settings' },
+    { id: 'privacy', name: 'Data & Privacy', href: '/settings/privacy' },
     { id: 'billing', name: 'Billing', href: '/settings/billing' },
+    { id: 'advanced', name: 'Advanced', href: '/settings/advanced' },
   ]
 
   return (

--- a/pickleglass_web/backend_node/index.js
+++ b/pickleglass_web/backend_node/index.js
@@ -26,6 +26,7 @@ function createApp() {
     app.use('/api/user', require('./routes/user'));
     app.use('/api/conversations', require('./routes/conversations'));
     app.use('/api/presets', require('./routes/presets'));
+    app.use('/api/network', require('./routes/network'));
 
     app.get('/api/sync/status', (req, res) => {
         res.json({

--- a/pickleglass_web/backend_node/routes/network.js
+++ b/pickleglass_web/backend_node/routes/network.js
@@ -1,0 +1,96 @@
+const express = require('express');
+const router = express.Router();
+
+// Helper function to communicate with main process if available
+async function sendToMainProcess(channel, ...args) {
+    try {
+        // Check if we're running in Electron context
+        if (global.electronIpc) {
+            return await global.electronIpc.invoke(channel, ...args);
+        }
+        
+        // If not in Electron, return default values
+        console.log('[Network API] Not in Electron context, returning defaults');
+        return null;
+    } catch (error) {
+        console.error(`[Network API] Failed to communicate with main process:`, error);
+        return null;
+    }
+}
+
+// Get current network settings
+router.get('/settings', async (req, res) => {
+    try {
+        console.log('[Network API] GET /settings called');
+        
+        // Try to get settings from main process
+        const settings = await sendToMainProcess('get-network-settings');
+        
+        if (settings) {
+            console.log('[Network API] Retrieved settings from main process:', settings);
+            res.json(settings);
+        } else {
+            // Return default settings if not in Electron context
+            const defaultSettings = {
+                apiPort: null,
+                webPort: null,
+                lockPorts: false,
+                currentApiPort: process.env.pickleglass_API_PORT ? parseInt(process.env.pickleglass_API_PORT) : null,
+                currentWebPort: process.env.pickleglass_WEB_PORT ? parseInt(process.env.pickleglass_WEB_PORT) : null
+            };
+            console.log('[Network API] Returning default settings:', defaultSettings);
+            res.json(defaultSettings);
+        }
+    } catch (error) {
+        console.error('[Network API] Failed to get network settings:', error);
+        res.status(500).json({ error: 'Failed to retrieve network settings' });
+    }
+});
+
+// Save network settings
+router.post('/settings', async (req, res) => {
+    try {
+        console.log('[Network API] POST /settings called with:', req.body);
+        
+        const result = await sendToMainProcess('save-network-settings', req.body);
+        
+        if (result) {
+            console.log('[Network API] Settings saved successfully');
+            res.json({ success: true, message: 'Network settings saved successfully' });
+        } else {
+            console.log('[Network API] Main process not available, settings not saved');
+            res.status(503).json({ 
+                error: 'Settings cannot be saved - main process not available',
+                message: 'Network settings require the desktop application to be running'
+            });
+        }
+    } catch (error) {
+        console.error('[Network API] Failed to save network settings:', error);
+        res.status(500).json({ error: 'Failed to save network settings' });
+    }
+});
+
+// Lock current ports
+router.post('/lock-ports', async (req, res) => {
+    try {
+        console.log('[Network API] POST /lock-ports called');
+        
+        const result = await sendToMainProcess('lock-current-ports');
+        
+        if (result) {
+            console.log('[Network API] Ports locked successfully');
+            res.json({ success: true, message: 'Current ports locked successfully' });
+        } else {
+            console.log('[Network API] Main process not available, ports not locked');
+            res.status(503).json({ 
+                error: 'Ports cannot be locked - main process not available',
+                message: 'Port locking requires the desktop application to be running'
+            });
+        }
+    } catch (error) {
+        console.error('[Network API] Failed to lock current ports:', error);
+        res.status(500).json({ error: 'Failed to lock current ports' });
+    }
+});
+
+module.exports = router; 

--- a/pickleglass_web/components/Sidebar.tsx
+++ b/pickleglass_web/components/Sidebar.tsx
@@ -210,6 +210,7 @@ const SidebarComponent = ({ isCollapsed, onToggle, onSearchClick }: SidebarProps
             { name: 'Personal Profile', href: '/settings', icon: '/user.svg', isLucide: false, ariaLabel: 'Personal profile settings' },
             { name: 'Data & privacy', href: '/settings/privacy', icon: '/privacy.svg', isLucide: false, ariaLabel: 'Data and privacy settings' },
             { name: 'Billing', href: '/settings/billing', icon: '/credit-card.svg', isLucide: false, ariaLabel: 'Billing settings' },
+            { name: 'Advanced', href: '/settings/advanced', icon: '/setting.svg', isLucide: false, ariaLabel: 'Advanced settings' },
         ],
         []
     );

--- a/src/common/config/config.js
+++ b/src/common/config/config.js
@@ -12,6 +12,11 @@ class Config {
             
             webUrl: process.env.pickleglass_WEB_URL || 'http://localhost:3000',
             
+            // Network Settings
+            apiPort: null, // null means auto-assign
+            webPort: null, // null means auto-assign
+            lockPorts: false, // whether to lock the current ports
+            
             enableJWT: false,
             fallbackToHeaderAuth: false,
             
@@ -46,6 +51,17 @@ class Config {
         if (process.env.pickleglass_WEB_URL) {
             this.config.webUrl = process.env.pickleglass_WEB_URL;
             console.log(`[Config] Web URL from env: ${this.config.webUrl}`);
+        }
+        
+        // Load port configuration from environment
+        if (process.env.pickleglass_API_PORT) {
+            this.config.apiPort = parseInt(process.env.pickleglass_API_PORT);
+            console.log(`[Config] API Port from env: ${this.config.apiPort}`);
+        }
+        
+        if (process.env.pickleglass_WEB_PORT) {
+            this.config.webPort = parseInt(process.env.pickleglass_WEB_PORT);
+            console.log(`[Config] Web Port from env: ${this.config.webPort}`);
         }
         
         if (process.env.pickleglass_API_TIMEOUT) {


### PR DESCRIPTION
I was a bit frustrated about having a new port for the backend each time I restarted the app and thus not able to reload the "old" web-tab.

I have added 'Advanced' tab to settings pages, updated IPC communication for network settings, and improved port management in backend configuration.

<img width="1388" alt="image" src="https://github.com/user-attachments/assets/e67242cc-0ae6-4adb-8bd5-092beb6f0530" />

Either set the ports to a static value, lock the current automatically assigned ports or unlock them to be automatically assigned again.

The Advanced settings segment is expandable for further settings in the future.