### PR TITLE
Feature : Soniox STT Provider Implemented

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4172,28 +4172,6 @@
                 "node": ">= 8"
             }
         },
-        "node_modules/fs-temp": {
-            "version": "1.2.1",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "random-path": "^0.1.0"
-            }
-        },
-        "node_modules/fs-xattr": {
-            "version": "0.3.1",
-            "dev": true,
-            "hasInstallScript": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "!win32"
-            ],
-            "engines": {
-                "node": ">=8.6.0"
-            }
-        },
         "node_modules/fs.realpath": {
             "version": "1.0.0",
             "dev": true,
@@ -5156,19 +5134,6 @@
             "dependencies": {
                 "lodash.clonedeep": "^4.5.0",
                 "lru-cache": "6.0.0"
-            }
-        },
-        "node_modules/macos-alias": {
-            "version": "0.2.12",
-            "dev": true,
-            "hasInstallScript": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "dependencies": {
-                "nan": "^2.4.0"
             }
         },
         "node_modules/make-fetch-happen": {

--- a/src/common/ai/factory.js
+++ b/src/common/ai/factory.js
@@ -85,6 +85,14 @@ const PROVIDERS = {
           { id: 'whisper-medium', name: 'Whisper Medium (769M)' },
       ],
   },
+  'soniox': {
+      name: 'Soniox',
+      handler: () => require("./providers/soniox"),
+      llmModels: [],
+      sttModels: [
+          { id: 'en_v2', name: 'Soniox English v2' }
+      ],
+  },
 };
 
 function sanitizeModelId(model) {

--- a/src/common/ai/providers/soniox.js
+++ b/src/common/ai/providers/soniox.js
@@ -1,0 +1,93 @@
+// Soniox STT Provider
+// https://soniox.com/docs
+
+const https = require('https');
+const EventEmitter = require('events');
+
+class SonioxSTTSession extends EventEmitter {
+    constructor(apiKey, model = 'en_v2', sessionId) {
+        super();
+        this.apiKey = apiKey;
+        this.model = model;
+        this.sessionId = sessionId || `soniox_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
+        this.isRunning = false;
+        this.audioBuffer = Buffer.alloc(0);
+        this.lastTranscription = '';
+    }
+
+    async initialize() {
+        this.isRunning = true;
+        // Soniox does not require model download, just API key
+        return true;
+    }
+
+    async transcribe(audioBuffer) {
+        // See https://soniox.com/docs/speech-recognition/api.html#recognize-audio
+        return new Promise((resolve, reject) => {
+            const options = {
+                hostname: 'api.soniox.com',
+                path: `/v2/recognize`,
+                method: 'POST',
+                headers: {
+                    'Authorization': `Bearer ${this.apiKey}`,
+                    'Content-Type': 'audio/wav',
+                    'Accept': 'application/json',
+                    'soniox-model': this.model
+                }
+            };
+            const req = https.request(options, res => {
+                let data = '';
+                res.on('data', chunk => data += chunk);
+                res.on('end', () => {
+                    try {
+                        const json = JSON.parse(data);
+                        resolve(json);
+                    } catch (e) {
+                        reject(e);
+                    }
+                });
+            });
+            req.on('error', reject);
+            req.write(audioBuffer);
+            req.end();
+        });
+    }
+
+    async processAudioChunk(audioBuffer) {
+        if (!this.isRunning) return;
+        try {
+            const result = await this.transcribe(audioBuffer);
+            const text = result.text || '';
+            this.lastTranscription = text;
+            this.emit('transcription', { text, isFinal: true });
+        } catch (err) {
+            this.emit('error', err);
+        }
+    }
+
+    async sendRealtimeInput(audioBuffer) {
+        // Accepts Buffer or base64 string
+        if (typeof audioBuffer === 'string') {
+            audioBuffer = Buffer.from(audioBuffer, 'base64');
+        }
+        await this.processAudioChunk(audioBuffer);
+    }
+
+    stop() {
+        this.isRunning = false;
+    }
+
+    close() {
+        this.stop();
+        this.removeAllListeners();
+    }
+}
+
+function createSTT(opts) {
+    return new SonioxSTTSession(opts.apiKey, opts.model);
+}
+
+module.exports = {
+    createSTT,
+    SonioxSTTSession
+};

--- a/src/common/services/modelStateService.js
+++ b/src/common/services/modelStateService.js
@@ -188,6 +188,16 @@ class ModelStateService {
                     this.setApiKey(provider, key);
                     return { success: true };
                 }
+            case 'soniox': {
+                // Soniox API key is a 32+ char string, optionally validate format or do a real API call
+                if (typeof key !== 'string' || key.length < 32) {
+                    return { success: false, error: 'Invalid Soniox API key format.' };
+                }
+                
+                this.setApiKey(provider, key);
+                console.log(`[ModelStateService] API key for ${provider} is valid.`);
+                return { success: true };
+            }
             default:
                 return { success: false, error: 'Unknown provider.' };
         }

--- a/src/features/listen/stt/sttService.js
+++ b/src/features/listen/stt/sttService.js
@@ -133,37 +133,18 @@ class SttService {
                 return;
             }
             
-            if (this.modelInfo.provider === 'whisper') {
-                // Whisper STT emits 'transcription' events with different structure
+            if (this.modelInfo.provider === 'whisper' || this.modelInfo.provider === 'soniox') {
+                // Whisper and Soniox STT emit 'transcription' events with similar structure
                 if (message.text && message.text.trim()) {
                     const finalText = message.text.trim();
-                    
-                    // Filter out Whisper noise transcriptions
+                    // Filter out noise for Whisper, for Soniox just check length
                     const noisePatterns = [
-                        '[BLANK_AUDIO]',
-                        '[INAUDIBLE]',
-                        '[MUSIC]',
-                        '[SOUND]',
-                        '[NOISE]',
-                        '(BLANK_AUDIO)',
-                        '(INAUDIBLE)',
-                        '(MUSIC)',
-                        '(SOUND)',
-                        '(NOISE)'
+                        '[BLANK_AUDIO]', '[INAUDIBLE]', '[MUSIC]', '[SOUND]', '[NOISE]',
+                        '(BLANK_AUDIO)', '(INAUDIBLE)', '(MUSIC)', '(SOUND)', '(NOISE)'
                     ];
-                    
-
-                    
-                    const normalizedText = finalText.toLowerCase().trim();
-                    
-                    const isNoise = noisePatterns.some(pattern => 
-                        finalText.includes(pattern) || finalText === pattern
-                    );
-                    
-                    
+                    const isNoise = this.modelInfo.provider === 'whisper' && noisePatterns.some(pattern => finalText.includes(pattern) || finalText === pattern);
                     if (!isNoise && finalText.length > 2) {
                         this.debounceMyCompletion(finalText);
-                        
                         this.sendToRenderer('stt-update', {
                             speaker: 'Me',
                             text: finalText,
@@ -171,7 +152,7 @@ class SttService {
                             isFinal: true,
                             timestamp: Date.now(),
                         });
-                    } else {
+                    } else if (this.modelInfo.provider === 'whisper') {
                         console.log(`[Whisper-Me] Filtered noise: "${finalText}"`);
                     }
                 }
@@ -246,37 +227,16 @@ class SttService {
                 return;
             }
             
-            if (this.modelInfo.provider === 'whisper') {
-                // Whisper STT emits 'transcription' events with different structure
+            if (this.modelInfo.provider === 'whisper' || this.modelInfo.provider === 'soniox') {
                 if (message.text && message.text.trim()) {
                     const finalText = message.text.trim();
-                    
-                    // Filter out Whisper noise transcriptions
                     const noisePatterns = [
-                        '[BLANK_AUDIO]',
-                        '[INAUDIBLE]',
-                        '[MUSIC]',
-                        '[SOUND]',
-                        '[NOISE]',
-                        '(BLANK_AUDIO)',
-                        '(INAUDIBLE)',
-                        '(MUSIC)',
-                        '(SOUND)',
-                        '(NOISE)'
+                        '[BLANK_AUDIO]', '[INAUDIBLE]', '[MUSIC]', '[SOUND]', '[NOISE]',
+                        '(BLANK_AUDIO)', '(INAUDIBLE)', '(MUSIC)', '(SOUND)', '(NOISE)'
                     ];
-                    
-                    
-                    const normalizedText = finalText.toLowerCase().trim();
-                    
-                    const isNoise = noisePatterns.some(pattern => 
-                        finalText.includes(pattern) || finalText === pattern
-                    );
-                    
-                    
-                    // Only process if it's not noise, not a false positive, and has meaningful content
+                    const isNoise = this.modelInfo.provider === 'whisper' && noisePatterns.some(pattern => finalText.includes(pattern) || finalText === pattern);
                     if (!isNoise && finalText.length > 2) {
                         this.debounceTheirCompletion(finalText);
-                        
                         this.sendToRenderer('stt-update', {
                             speaker: 'Them',
                             text: finalText,
@@ -284,7 +244,7 @@ class SttService {
                             isFinal: true,
                             timestamp: Date.now(),
                         });
-                    } else {
+                    } else if (this.modelInfo.provider === 'whisper') {
                         console.log(`[Whisper-Them] Filtered noise: "${finalText}"`);
                     }
                 }
@@ -613,4 +573,4 @@ class SttService {
     }
 }
 
-module.exports = SttService; 
+module.exports = SttService;


### PR DESCRIPTION
### **Integrate Soniox as STT Provider in Glass App**

This PR adds support for Soniox as a speech-to-text (STT) provider in the Electron-based Glass app. Users can now select Soniox as their STT provider, validate their API key, and use Soniox for real-time transcription, similar to Whisper.

## Summary of Changes
**Soniox Provider Integration**

- Implemented [SonioxSTTSession](vscode-file://vscode-app/snap/code/196/usr/share/code/resources/app/out/vs/code/electron-sandbox/workbench/workbench.html) in [soniox.js](vscode-file://vscode-app/snap/code/196/usr/share/code/resources/app/out/vs/code/electron-sandbox/workbench/workbench.html) with real-time transcription using the Soniox API.
- Added a [close()](vscode-file://vscode-app/snap/code/196/usr/share/code/resources/app/out/vs/code/electron-sandbox/workbench/workbench.html) method to match the expected STT session interface.
- Registered Soniox in the [PROVIDERS](vscode-file://vscode-app/snap/code/196/usr/share/code/resources/app/out/vs/code/electron-sandbox/workbench/workbench.html) object in [factory.js](vscode-file://vscode-app/snap/code/196/usr/share/code/resources/app/out/vs/code/electron-sandbox/workbench/workbench.html) with its model.

**API Key Validation**

- Updated [modelStateService.js](vscode-file://vscode-app/snap/code/196/usr/share/code/resources/app/out/vs/code/electron-sandbox/workbench/workbench.html) to handle Soniox in [validateApiKey](vscode-file://vscode-app/snap/code/196/usr/share/code/resources/app/out/vs/code/electron-sandbox/workbench/workbench.html), including format validation and proper state updates.
- Ensured Soniox API key is saved and the provider/model is auto-selected after validation.
- 

**IPC & State Management**

- Removed duplicate [model:validate-key](vscode-file://vscode-app/snap/code/196/usr/share/code/resources/app/out/vs/code/electron-sandbox/workbench/workbench.html) IPC handler from [windowManager.js](vscode-file://vscode-app/snap/code/196/usr/share/code/resources/app/out/vs/code/electron-sandbox/workbench/workbench.html) to avoid Electron handler conflicts.
-  Ensured only [modelStateService.js](vscode-file://vscode-app/snap/code/196/usr/share/code/resources/app/out/vs/code/electron-sandbox/workbench/workbench.html) manages API key validation and state.


## Related Issue

- Closes #89 

## Contributor's Self-Review Checklist

Please check the boxes that apply. This is a reminder of what we look for in a good pull request.

- I have read the [CONTRIBUTING.md](https://github.com/your-org/your-repo/blob/main/CONTRIBUTING.md) document.
-  My code follows the project's coding style and architectural patterns as described in [DESIGN_PATTERNS.md](https://github.com/your-org/your-repo/blob/main/docs/DESIGN_PATTERNS.md).
- I have added or updated relevant tests for my changes.
- I have updated the documentation to reflect my changes (if applicable).
- My changes have been tested locally and are working as expected.

## Additional Context (Optional)

- Manually tested Soniox selection and API key validation in the UI.
- Verified Soniox is selectable and persists as the current STT provider.
- Confirmed real-time transcription works with Soniox.
- Ensured no "Unknown provider" or IPC handler errors occur.
- Validated that the listen service starts and stops Soniox sessions without errors.

** Logs :**
[ModelStateService] Selected STT model from newly configured provider soniox: en_v2
[ModelStateService] State saved for user: default_user
[ModelStateService] Current Selection -> LLM: claude-3-5-sonnet-20241022 (Provider: anthropic), STT: en_v2 (Provider: soniox)
[ModelStateService] Current Selection -> LLM: claude-3-5-sonnet-20241022 (Provider: anthropic), STT: en_v2 (Provider: soniox)
[ModelStateService] API key for soniox is valid.

<img width="1569" height="134" alt="image" src="https://github.com/user-attachments/assets/5d5cad21-5862-42c8-b49e-e7f9b9348050" />


@samtiz @entry-sanio @jhyang0 @ekim425  Please Review the PR & give me feedback.
I would also review the PR once again from my end. 