### PR TITLE
fix: prevent application from stealing focus

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -66,7 +66,6 @@ function setupProtocolHandling() {
     app.on('second-instance', (event, commandLine, workingDirectory) => {
         console.log('[Protocol] Second instance command line:', commandLine);
         
-        focusMainWindow();
         
         let protocolUrl = null;
         
@@ -118,30 +117,6 @@ function setupProtocolHandling() {
     });
 }
 
-function focusMainWindow() {
-    const { windowPool } = require('./window/windowManager.js');
-    if (windowPool) {
-        const header = windowPool.get('header');
-        if (header && !header.isDestroyed()) {
-            if (header.isMinimized()) header.restore();
-            header.focus();
-            return true;
-        }
-    }
-    
-    // Fallback: focus any available window
-    const windows = BrowserWindow.getAllWindows();
-    if (windows.length > 0) {
-        const mainWindow = windows[0];
-        if (!mainWindow.isDestroyed()) {
-            if (mainWindow.isMinimized()) mainWindow.restore();
-            mainWindow.focus();
-            return true;
-        }
-    }
-    
-    return false;
-}
 
 if (process.platform === 'win32') {
     for (const arg of process.argv) {
@@ -482,7 +457,6 @@ async function handleCustomUrl(url) {
                 const header = windowPool.get('header');
                 if (header) {
                     if (header.isMinimized()) header.restore();
-                    header.focus();
                     
                     const targetUrl = `http://localhost:${WEB_PORT}/${action}`;
                     console.log(`[Custom URL] Navigating webview to: ${targetUrl}`);
@@ -544,7 +518,6 @@ async function handleFirebaseAuthCallback(params) {
         const header = windowPool.get('header');
         if (header) {
             if (header.isMinimized()) header.restore();
-            header.focus();
         } else {
             console.error('[Auth] Header window not found after auth callback.');
         }
@@ -569,7 +542,6 @@ function handlePersonalizeFromUrl(params) {
     
     if (header) {
         if (header.isMinimized()) header.restore();
-        header.focus();
         
         const personalizeUrl = `http://localhost:${WEB_PORT}/settings`;
         console.log(`[Custom URL] Navigating to personalize page: ${personalizeUrl}`);

--- a/src/window/windowManager.js
+++ b/src/window/windowManager.js
@@ -656,11 +656,11 @@ function createWindows() {
         transparent: true,
         vibrancy: false,
         hasShadow: false,
-        alwaysOnTop: true,
+        alwaysOnTop: false,
         skipTaskbar: true,
         hiddenInMissionControl: true,
         resizable: false,
-        focusable: true,
+        focusable: false,
         acceptFirstMouse: true,
         webPreferences: {
             nodeIntegration: false,
@@ -727,22 +727,6 @@ function createWindows() {
         header.webContents.openDevTools({ mode: 'detach' });
     }
 
-    header.on('focus', () => {
-        console.log('[WindowManager] Header gained focus');
-    });
-
-    header.on('blur', () => {
-        console.log('[WindowManager] Header lost focus');
-    });
-
-    header.webContents.on('before-input-event', (event, input) => {
-        if (input.type === 'mouseDown') {
-            const target = input.target;
-            if (target && (target.includes('input') || target.includes('apikey'))) {
-                header.focus();
-            }
-        }
-    });
 
     header.on('resize', () => updateChildWindowLayouts(false));
 


### PR DESCRIPTION
- Disabled alwaysOnTop and focusable properties for the main window.
- Removed all calls to focusMainWindow and header.focus() to prevent the application from stealing focus from other applications.

---
name: Pull Request
about: Propose a change to the codebase
---

## Summary of Changes

Please provide a brief, high-level summary of the changes in this pull request.

## Related Issue

- Closes #XXX

*Please replace `XXX` with the issue number that this pull request resolves. If it does not resolve a specific issue, please explain why this change is needed.*

## Contributor's Self-Review Checklist

Please check the boxes that apply. This is a reminder of what we look for in a good pull request.

- [ ] I have read the [CONTRIBUTING.md](https://github.com/your-org/your-repo/blob/main/CONTRIBUTING.md) document.
- [ ] My code follows the project's coding style and architectural patterns as described in [DESIGN_PATTERNS.md](https://github.com/your-org/your-repo/blob/main/docs/DESIGN_PATTERNS.md).
- [ ] I have added or updated relevant tests for my changes.
- [ ] I have updated the documentation to reflect my changes (if applicable).
- [ ] My changes have been tested locally and are working as expected.

## Additional Context (Optional)

Add any other context or screenshots about the pull request here. 