### PR TITLE
Feat/improve preset editing

### DIFF
--- a/pickleglass_web/app/personalize/page.tsx
+++ b/pickleglass_web/app/personalize/page.tsx
@@ -416,17 +416,16 @@ export default function PersonalizePage() {
           <textarea
             value={modalContent}
             onChange={(e) => handleModalContentChange(e.target.value)}
-            className="w-full h-48 sm:h-56 md:h-64 lg:h-72 p-3 sm:p-4 border border-gray-300 rounded-md resize-none focus:ring-2 focus:ring-blue-500 focus:border-transparent font-mono text-sm leading-relaxed"
+            className="w-full h-64 sm:h-72 md:h-80 lg:h-96 p-3 sm:p-4 border border-gray-300 rounded-md resize-none focus:ring-2 focus:ring-blue-500 focus:border-transparent font-mono text-sm leading-relaxed"
             placeholder="Enter your prompt content here..."
             readOnly={modalPreset?.is_default === 1}
           />
           
-          <div className="flex flex-col sm:flex-row sm:justify-between gap-2 text-xs text-gray-500">
-            <span>Character count: {modalContent.length}</span>
-            {modalPreset?.is_default === 1 && (
-              <span className="text-yellow-600">Default presets cannot be modified</span>
-            )}
-          </div>
+          {modalPreset?.is_default === 1 && (
+            <div className="text-xs text-yellow-600">
+              Default presets cannot be modified
+            </div>
+          )}
         </div>
       </Modal>
      

--- a/pickleglass_web/app/personalize/page.tsx
+++ b/pickleglass_web/app/personalize/page.tsx
@@ -220,7 +220,27 @@ export default function PersonalizePage() {
       setIsModalOpen(false);
     } catch (error) {
       console.error('Failed to save modal changes:', error);
-      alert('Failed to save preset. See console for details.');
+      
+      // Enhanced error handling with specific error types
+      let errorMessage = 'Failed to save preset. Please try again.';
+      
+      if (error instanceof Error) {
+        // Check for specific error types
+        if (error.message.includes('network') || error.message.includes('fetch')) {
+          errorMessage = 'Network error. Please check your connection and try again.';
+        } else if (error.message.includes('401') || error.message.includes('unauthorized')) {
+          errorMessage = 'Authentication error. Please log in again.';
+        } else if (error.message.includes('403') || error.message.includes('forbidden')) {
+          errorMessage = 'You do not have permission to edit this preset.';
+        } else if (error.message.includes('404')) {
+          errorMessage = 'Preset not found. It may have been deleted.';
+        } else if (error.message.includes('500')) {
+          errorMessage = 'Server error. Please try again later.';
+        }
+      }
+      
+      alert(errorMessage);
+      
     } finally {
       setSaving(false);
     }
@@ -359,13 +379,13 @@ export default function PersonalizePage() {
         footer={
           <>
             <button 
-              className="px-4 py-2 text-gray-600 border border-gray-300 rounded-md hover:bg-gray-50 transition-colors"
+              className="px-4 py-2 text-gray-600 border border-gray-300 rounded-md hover:bg-gray-50 transition-colors w-full sm:w-auto"
               onClick={closeModal}
             >
               Cancel
             </button>
             <button 
-              className={`px-4 py-2 rounded-md transition-colors ${
+              className={`px-4 py-2 rounded-md transition-colors w-full sm:w-auto ${
                 modalIsDirty 
                   ? 'bg-blue-600 text-white hover:bg-blue-700' 
                   : 'bg-gray-400 text-white cursor-not-allowed'
@@ -377,17 +397,17 @@ export default function PersonalizePage() {
             </button>
           </>
         }
-        className="max-w-4xl"
+        className="w-[95%] sm:w-[90%] md:w-[85%] lg:w-[80%] max-w-4xl"
       >
         <div className="space-y-4">
-          <div className="flex items-center justify-between">
+          <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
             {modalIsDirty && (
-              <span className="text-sm text-orange-600 bg-orange-100 px-2 py-1 rounded">
+              <span className="text-sm text-orange-600 bg-orange-100 px-2 py-1 rounded inline-block">
                 Unsaved changes
               </span>
             )}
             {modalPreset?.is_default === 1 && (
-              <span className="text-sm text-yellow-600 bg-yellow-100 px-2 py-1 rounded">
+              <span className="text-sm text-yellow-600 bg-yellow-100 px-2 py-1 rounded inline-block">
                 Read-only (Default preset)
               </span>
             )}
@@ -396,12 +416,12 @@ export default function PersonalizePage() {
           <textarea
             value={modalContent}
             onChange={(e) => handleModalContentChange(e.target.value)}
-            className="w-full h-64 p-4 border border-gray-300 rounded-md resize-none focus:ring-2 focus:ring-blue-500 focus:border-transparent font-mono text-sm"
+            className="w-full h-48 sm:h-56 md:h-64 lg:h-72 p-3 sm:p-4 border border-gray-300 rounded-md resize-none focus:ring-2 focus:ring-blue-500 focus:border-transparent font-mono text-sm leading-relaxed"
             placeholder="Enter your prompt content here..."
             readOnly={modalPreset?.is_default === 1}
           />
           
-          <div className="flex justify-between text-xs text-gray-500">
+          <div className="flex flex-col sm:flex-row sm:justify-between gap-2 text-xs text-gray-500">
             <span>Character count: {modalContent.length}</span>
             {modalPreset?.is_default === 1 && (
               <span className="text-yellow-600">Default presets cannot be modified</span>

--- a/pickleglass_web/app/personalize/page.tsx
+++ b/pickleglass_web/app/personalize/page.tsx
@@ -165,7 +165,6 @@ export default function PersonalizePage() {
 
   const closeModal = () => {
     if (modalIsDirty) {
-      // Show confirmation dialog for unsaved changes
       const shouldClose = window.confirm(
         'You have unsaved changes in the modal editor. Are you sure you want to close without saving?'
       );
@@ -202,7 +201,6 @@ export default function PersonalizePage() {
       return;
     }
 
-    // Validate title is not empty
     if (!modalTitle.trim()) {
       alert('Preset title cannot be empty.');
       return;
@@ -333,36 +331,34 @@ export default function PersonalizePage() {
           </div>
           
           {showPresets && (
-            <div className="flex-1 overflow-auto">
-              <div className="grid grid-cols-5 gap-4 auto-rows-max">
-                {allPresets.map((preset) => (
-                  <div
-                    key={preset.id}
-                    onClick={() => handlePresetClick(preset)}
-                    onDoubleClick={() => openModalWithPreset(preset)}
-                    className={`
-                      p-4 rounded-lg cursor-pointer transition-all duration-200 bg-white
-                      h-48 flex flex-col shadow-sm hover:shadow-md relative
-                      ${selectedPreset?.id === preset.id
-                        ? 'border-2 border-blue-500 shadow-md'
-                        : 'border border-gray-200 hover:border-gray-300'
-                      }
-                    `}
-                  >
-                    {preset.is_default === 1 && (
-                      <div className="absolute top-2 right-2 bg-yellow-100 text-yellow-800 text-xs px-2 py-1 rounded-full">
-                        Default
-                      </div>
-                    )}
-                    <h3 className="font-semibold text-gray-900 mb-3 text-center text-sm">
-                      {preset.title}
-                    </h3>
-                    <p className="text-xs text-gray-600 leading-relaxed flex-1 overflow-hidden">
-                      {preset.prompt.substring(0, 100) + (preset.prompt.length > 100 ? '...' : '')}
-                    </p>
-                  </div>
-                ))}
-              </div>
+            <div className="grid grid-cols-5 gap-4 mb-6">
+              {allPresets.map((preset) => (
+                <div
+                  key={preset.id}
+                  onClick={() => handlePresetClick(preset)}
+                  onDoubleClick={() => openModalWithPreset(preset)}
+                  className={`
+                    p-4 rounded-lg cursor-pointer transition-all duration-200 bg-white
+                    h-48 flex flex-col shadow-sm hover:shadow-md relative
+                    ${selectedPreset?.id === preset.id
+                      ? 'border-2 border-blue-500 shadow-md'
+                      : 'border border-gray-200 hover:border-gray-300'
+                    }
+                  `}
+                >
+                  {preset.is_default === 1 && (
+                    <div className="absolute top-2 right-2 bg-yellow-100 text-yellow-800 text-xs px-2 py-1 rounded-full">
+                      Default
+                    </div>
+                  )}
+                  <h3 className="font-semibold text-gray-900 mb-3 text-center text-sm">
+                    {preset.title}
+                  </h3>
+                  <p className="text-xs text-gray-600 leading-relaxed flex-1 overflow-hidden">
+                    {preset.prompt.substring(0, 100) + (preset.prompt.length > 100 ? '...' : '')}
+                  </p>
+                </div>
+              ))}
             </div>
           )}
         </div>

--- a/pickleglass_web/app/personalize/page.tsx
+++ b/pickleglass_web/app/personalize/page.tsx
@@ -3,8 +3,7 @@
 import { useState, useEffect } from 'react'
 import { ChevronDown, Plus, Copy } from 'lucide-react'
 import { getPresets, updatePreset, createPreset, PromptPreset } from '@/utils/api'
-import ModalTest from '@/components/ModalTest'
-import PresetModalTest from '@/components/PresetModalTest'
+import Modal from '@/components/Modal'
 
 export default function PersonalizePage() {
   const [allPresets, setAllPresets] = useState<PromptPreset[]>([]);
@@ -155,7 +154,6 @@ export default function PersonalizePage() {
     }
   };
 
-  // Modal helper functions
   const openModalWithPreset = (preset: PromptPreset) => {
     setModalPreset(preset);
     setModalContent(preset.prompt);
@@ -293,6 +291,7 @@ export default function PersonalizePage() {
                 <div
                   key={preset.id}
                   onClick={() => handlePresetClick(preset)}
+                  onDoubleClick={() => openModalWithPreset(preset)}
                   className={`
                     p-4 rounded-lg cursor-pointer transition-all duration-200 bg-white
                     h-48 flex flex-col shadow-sm hover:shadow-md relative
@@ -343,6 +342,64 @@ export default function PersonalizePage() {
         </div>
       </div>
       
+      {/* Preset Editor Modal */}
+      <Modal
+        isOpen={isModalOpen}
+        onClose={closeModal}
+        title={`Preset: ${modalPreset?.title || ''}`}
+        footer={
+          <>
+            <button 
+              className="px-4 py-2 text-gray-600 border border-gray-300 rounded-md hover:bg-gray-50 transition-colors"
+              onClick={closeModal}
+            >
+              Cancel
+            </button>
+            <button 
+              className={`px-4 py-2 rounded-md transition-colors ${
+                modalIsDirty 
+                  ? 'bg-blue-600 text-white hover:bg-blue-700' 
+                  : 'bg-gray-400 text-white cursor-not-allowed'
+              }`}
+              onClick={saveModalChanges}
+              disabled={!modalIsDirty || saving}
+            >
+              {saving ? 'Saving...' : 'Save Changes'}
+            </button>
+          </>
+        }
+        className="max-w-4xl"
+      >
+        <div className="space-y-4">
+          <div className="flex items-center justify-between">
+            {modalIsDirty && (
+              <span className="text-sm text-orange-600 bg-orange-100 px-2 py-1 rounded">
+                Unsaved changes
+              </span>
+            )}
+            {modalPreset?.is_default === 1 && (
+              <span className="text-sm text-yellow-600 bg-yellow-100 px-2 py-1 rounded">
+                Read-only (Default preset)
+              </span>
+            )}
+          </div>
+          
+          <textarea
+            value={modalContent}
+            onChange={(e) => handleModalContentChange(e.target.value)}
+            className="w-full h-64 p-4 border border-gray-300 rounded-md resize-none focus:ring-2 focus:ring-blue-500 focus:border-transparent font-mono text-sm"
+            placeholder="Enter your prompt content here..."
+            readOnly={modalPreset?.is_default === 1}
+          />
+          
+          <div className="flex justify-between text-xs text-gray-500">
+            <span>Character count: {modalContent.length}</span>
+            {modalPreset?.is_default === 1 && (
+              <span className="text-yellow-600">Default presets cannot be modified</span>
+            )}
+          </div>
+        </div>
+      </Modal>
      
     </div>
   );

--- a/pickleglass_web/app/personalize/page.tsx
+++ b/pickleglass_web/app/personalize/page.tsx
@@ -197,16 +197,25 @@ export default function PersonalizePage() {
         prompt: modalContent,
       });
 
+      // Create the updated preset object
+      const updatedPreset = { ...modalPreset, prompt: modalContent };
+      
       // Update the preset in the main list
-      setAllPresets(prev => prev.map(p => (p.id === modalPreset.id ? { ...p, prompt: modalContent } : p)));
+      setAllPresets(prev => prev.map(p => 
+        p.id === modalPreset.id ? updatedPreset : p
+      ));
       
       // Update selected preset if it's the same one
       if (selectedPreset?.id === modalPreset.id) {
-        setSelectedPreset({ ...modalPreset, prompt: modalContent });
+        setSelectedPreset(updatedPreset);
         setEditorContent(modalContent);
         setIsDirty(false);
       }
       
+      // Update modal preset state to reflect the saved changes
+      setModalPreset(updatedPreset);
+      
+      // Reset modal states and close
       setModalIsDirty(false);
       setIsModalOpen(false);
     } catch (error) {

--- a/pickleglass_web/app/personalize/page.tsx
+++ b/pickleglass_web/app/personalize/page.tsx
@@ -366,28 +366,7 @@ export default function PersonalizePage() {
         </div>
       </div>
 
-      <div className="flex-1 bg-white">
-        <div className="h-full px-8 py-6 flex flex-col">
-          {selectedPreset?.is_default === 1 && (
-            <div className="mb-4 p-4 bg-yellow-50 border border-yellow-200 rounded-lg">
-              <div className="flex items-center gap-2">
-                <div className="w-4 h-4 bg-yellow-400 rounded-full"></div>
-                <p className="text-sm text-yellow-800">
-                  <strong>This is a default preset and cannot be edited.</strong> 
-                  Use the "Duplicate" button above to create an editable copy, or create a new preset.
-                </p>
-              </div>
-            </div>
-          )}
-          <textarea
-            value={editorContent}
-            onChange={handleEditorChange}
-            className="w-full flex-1 text-sm text-gray-900 border-0 resize-none focus:outline-none bg-transparent font-mono leading-relaxed"
-            placeholder="Select a preset or type directly..."
-            readOnly={selectedPreset?.is_default === 1}
-          />
-        </div>
-      </div>
+      
       
       {/* Preset Editor Modal */}
       <Modal

--- a/pickleglass_web/app/personalize/page.tsx
+++ b/pickleglass_web/app/personalize/page.tsx
@@ -318,8 +318,8 @@ export default function PersonalizePage() {
         </div>
       </div>
 
-      <div className={`transition-colors duration-300 ${showPresets ? 'bg-gray-50' : 'bg-white'}`}>
-        <div className="px-8 py-6">
+      <div className={`flex-1 transition-colors duration-300 ${showPresets ? 'bg-gray-50' : 'bg-white'}`}>
+        <div className="h-full flex flex-col px-8 py-6">
           <div className="mb-6">
             <button
               onClick={() => setShowPresets(!showPresets)}
@@ -333,34 +333,36 @@ export default function PersonalizePage() {
           </div>
           
           {showPresets && (
-            <div className="grid grid-cols-5 gap-4 mb-6">
-              {allPresets.map((preset) => (
-                <div
-                  key={preset.id}
-                  onClick={() => handlePresetClick(preset)}
-                  onDoubleClick={() => openModalWithPreset(preset)}
-                  className={`
-                    p-4 rounded-lg cursor-pointer transition-all duration-200 bg-white
-                    h-48 flex flex-col shadow-sm hover:shadow-md relative
-                    ${selectedPreset?.id === preset.id
-                      ? 'border-2 border-blue-500 shadow-md'
-                      : 'border border-gray-200 hover:border-gray-300'
-                    }
-                  `}
-                >
-                  {preset.is_default === 1 && (
-                    <div className="absolute top-2 right-2 bg-yellow-100 text-yellow-800 text-xs px-2 py-1 rounded-full">
-                      Default
-                    </div>
-                  )}
-                  <h3 className="font-semibold text-gray-900 mb-3 text-center text-sm">
-                    {preset.title}
-                  </h3>
-                  <p className="text-xs text-gray-600 leading-relaxed flex-1 overflow-hidden">
-                    {preset.prompt.substring(0, 100) + (preset.prompt.length > 100 ? '...' : '')}
-                  </p>
-                </div>
-              ))}
+            <div className="flex-1 overflow-auto">
+              <div className="grid grid-cols-5 gap-4 auto-rows-max">
+                {allPresets.map((preset) => (
+                  <div
+                    key={preset.id}
+                    onClick={() => handlePresetClick(preset)}
+                    onDoubleClick={() => openModalWithPreset(preset)}
+                    className={`
+                      p-4 rounded-lg cursor-pointer transition-all duration-200 bg-white
+                      h-48 flex flex-col shadow-sm hover:shadow-md relative
+                      ${selectedPreset?.id === preset.id
+                        ? 'border-2 border-blue-500 shadow-md'
+                        : 'border border-gray-200 hover:border-gray-300'
+                      }
+                    `}
+                  >
+                    {preset.is_default === 1 && (
+                      <div className="absolute top-2 right-2 bg-yellow-100 text-yellow-800 text-xs px-2 py-1 rounded-full">
+                        Default
+                      </div>
+                    )}
+                    <h3 className="font-semibold text-gray-900 mb-3 text-center text-sm">
+                      {preset.title}
+                    </h3>
+                    <p className="text-xs text-gray-600 leading-relaxed flex-1 overflow-hidden">
+                      {preset.prompt.substring(0, 100) + (preset.prompt.length > 100 ? '...' : '')}
+                    </p>
+                  </div>
+                ))}
+              </div>
             </div>
           )}
         </div>

--- a/pickleglass_web/components/Modal.tsx
+++ b/pickleglass_web/components/Modal.tsx
@@ -70,9 +70,13 @@ const Modal: React.FC<ModalProps> = ({ isOpen, onClose, title, children, footer,
         };
     }, [isOpen, onClose, handleTabKey]);
 
-    // Handle click outside modal
+    // Handle click outside modal (only on larger screens where modal doesn't fill screen)
     const handleOverlayClick = (event: React.MouseEvent<HTMLDivElement>) => {
-        if (modalRef.current && !modalRef.current.contains(event.target as Node)) {
+        // Check if we're on a small screen (mobile) by checking window width
+        const isSmallScreen = window.innerWidth < 640; // 640px is Tailwind's 'sm' breakpoint
+        
+        // Only close on outside click if not on mobile (where modal is full-screen)
+        if (!isSmallScreen && modalRef.current && !modalRef.current.contains(event.target as Node)) {
             onClose();
         }
     };
@@ -121,38 +125,57 @@ const Modal: React.FC<ModalProps> = ({ isOpen, onClose, title, children, footer,
 
     return (
         <div 
-            className={`fixed inset-0 bg-black flex justify-center items-center z-50 transition-opacity duration-200 ${
+            className={`fixed inset-0 bg-black z-50 transition-opacity duration-200 ${
                 isAnimating ? 'bg-opacity-70' : 'bg-opacity-0'
-            }`} 
+            } 
+                /* Full screen on mobile, centered on larger screens */
+                flex sm:justify-center sm:items-center
+            `} 
             onClick={handleOverlayClick}
         >
             <div
                 ref={modalRef}
-                className={`bg-white rounded-lg shadow-xl w-[90%] max-w-2xl max-h-[90vh] flex flex-col overflow-hidden transition-all duration-200 transform ${
+                className={`bg-white flex flex-col overflow-hidden transition-all duration-200 transform ${
                     isAnimating 
                         ? 'scale-100 opacity-100 translate-y-0' 
                         : 'scale-95 opacity-0 translate-y-4'
-                } ${className}`}
+                } 
+                    /* Full screen on mobile */
+                    w-full h-full
+                    /* Modal style on larger screens */
+                    sm:w-[90%] sm:h-auto sm:max-h-[90vh] sm:rounded-lg sm:shadow-xl
+                    md:w-[85%] md:max-h-[85vh]
+                    lg:w-[80%] lg:max-h-[80vh]
+                    /* Allow custom sizing via className prop */
+                    ${className}`}
                 tabIndex={-1}
                 role="dialog"
                 aria-modal="true"
                 aria-labelledby="modal-title"
             >
                 {/* Modal Header */}
-                <div className="flex justify-between items-center p-6 border-b border-gray-200">
-                    <h2 id="modal-title" className="text-xl font-semibold text-gray-900">
+                <div className="flex justify-between items-center p-4 sm:p-6 border-b border-gray-200">
+                    <h2 id="modal-title" className="text-lg sm:text-xl font-semibold text-gray-900 truncate pr-4">
                         {title}
                     </h2>
-                    <button className="text-gray-400 hover:text-gray-600 text-2xl leading-none p-2 -m-2" onClick={onClose} aria-label="Close modal">
+                    <button 
+                        className="text-gray-400 hover:text-gray-600 text-2xl leading-none p-2 -m-2 flex-shrink-0" 
+                        onClick={onClose} 
+                        aria-label="Close modal"
+                    >
                         ×
                     </button>
                 </div>
 
                 {/* Modal Content */}
-                <div className="flex-1 p-6 overflow-y-auto">{children}</div>
+                <div className="flex-1 p-4 sm:p-6 overflow-y-auto">{children}</div>
 
                 {/* Modal Footer */}
-                {footer && <div className="flex justify-end gap-3 p-6 border-t border-gray-200">{footer}</div>}
+                {footer && (
+                    <div className="flex flex-col-reverse sm:flex-row justify-end gap-2 sm:gap-3 p-4 sm:p-6 border-t border-gray-200">
+                        {footer}
+                    </div>
+                )}
             </div>
         </div>
     );

--- a/pickleglass_web/components/Modal.tsx
+++ b/pickleglass_web/components/Modal.tsx
@@ -1,0 +1,161 @@
+import React, { useRef, useEffect, useState } from 'react';
+
+interface ModalProps {
+    isOpen: boolean;
+    onClose: () => void;
+    title: string;
+    children: React.ReactNode;
+    footer?: React.ReactNode;
+    className?: string;
+}
+
+const Modal: React.FC<ModalProps> = ({ isOpen, onClose, title, children, footer, className = '' }) => {
+    const modalRef = useRef<HTMLDivElement>(null);
+    const previousFocusRef = useRef<HTMLElement | null>(null);
+    const [isAnimating, setIsAnimating] = useState(false);
+    const [shouldRender, setShouldRender] = useState(false);
+
+    // Get all focusable elements within the modal
+    const getFocusableElements = (): NodeListOf<HTMLElement> | null => {
+        if (!modalRef.current) return null;
+        return modalRef.current.querySelectorAll(
+            'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"]):not([disabled])'
+        );
+    };
+
+    // Handle tab key for focus trapping
+    const handleTabKey = (event: KeyboardEvent) => {
+        if (event.key !== 'Tab') return;
+
+        const focusableElements = getFocusableElements();
+        if (!focusableElements || focusableElements.length === 0) return;
+
+        const firstElement = focusableElements[0];
+        const lastElement = focusableElements[focusableElements.length - 1];
+
+        if (event.shiftKey) {
+            // Shift + Tab: moving backwards
+            if (document.activeElement === firstElement) {
+                event.preventDefault();
+                lastElement.focus();
+            }
+        } else {
+            // Tab: moving forwards
+            if (document.activeElement === lastElement) {
+                event.preventDefault();
+                firstElement.focus();
+            }
+        }
+    };
+
+    // Handle keyboard events
+    useEffect(() => {
+        const handleKeyDown = (event: KeyboardEvent) => {
+            if (event.key === 'Escape') {
+                onClose();
+            } else if (event.key === 'Tab') {
+                handleTabKey(event);
+            }
+        };
+
+        if (isOpen) {
+            document.addEventListener('keydown', handleKeyDown);
+            // Prevent body scroll when modal is open
+            document.body.style.overflow = 'hidden';
+        }
+
+        return () => {
+            document.removeEventListener('keydown', handleKeyDown);
+            document.body.style.overflow = 'unset';
+        };
+    }, [isOpen, onClose]);
+
+    // Handle click outside modal
+    const handleOverlayClick = (event: React.MouseEvent<HTMLDivElement>) => {
+        if (modalRef.current && !modalRef.current.contains(event.target as Node)) {
+            onClose();
+        }
+    };
+
+    // Animation and render management
+    useEffect(() => {
+        if (isOpen) {
+            setShouldRender(true);
+            // Small delay to ensure DOM is ready before starting animation
+            setTimeout(() => setIsAnimating(true), 10);
+        } else {
+            setIsAnimating(false);
+            // Wait for animation to complete before unmounting
+            const timer = setTimeout(() => setShouldRender(false), 200);
+            return () => clearTimeout(timer);
+        }
+    }, [isOpen]);
+
+    // Focus management
+    useEffect(() => {
+        if (isOpen && isAnimating) {
+            // Store the previously focused element
+            previousFocusRef.current = document.activeElement as HTMLElement;
+            
+            // Focus the first focusable element in the modal
+            const focusableElements = getFocusableElements();
+            if (focusableElements && focusableElements.length > 0) {
+                focusableElements[0].focus();
+            } else if (modalRef.current) {
+                // Fallback: focus the modal container itself
+                modalRef.current.focus();
+            }
+        } else if (!isOpen && previousFocusRef.current) {
+            // Restore focus to the previously focused element when modal closes
+            try {
+                previousFocusRef.current.focus();
+            } catch (error) {
+                // Element might no longer exist, focus body as fallback
+                document.body.focus();
+            }
+            previousFocusRef.current = null;
+        }
+    }, [isOpen, isAnimating]);
+
+    if (!shouldRender) return null;
+
+    return (
+        <div 
+            className={`fixed inset-0 bg-black flex justify-center items-center z-50 transition-opacity duration-200 ${
+                isAnimating ? 'bg-opacity-70' : 'bg-opacity-0'
+            }`} 
+            onClick={handleOverlayClick}
+        >
+            <div
+                ref={modalRef}
+                className={`bg-white rounded-lg shadow-xl w-[90%] max-w-2xl max-h-[90vh] flex flex-col overflow-hidden transition-all duration-200 transform ${
+                    isAnimating 
+                        ? 'scale-100 opacity-100 translate-y-0' 
+                        : 'scale-95 opacity-0 translate-y-4'
+                } ${className}`}
+                tabIndex={-1}
+                role="dialog"
+                aria-modal="true"
+                aria-labelledby="modal-title"
+            >
+                {/* Modal Header */}
+                <div className="flex justify-between items-center p-6 border-b border-gray-200">
+                    <h2 id="modal-title" className="text-xl font-semibold text-gray-900">
+                        {title}
+                    </h2>
+                    <button className="text-gray-400 hover:text-gray-600 text-2xl leading-none p-2 -m-2" onClick={onClose} aria-label="Close modal">
+                        ×
+                    </button>
+                </div>
+
+                {/* Modal Content */}
+                <div className="flex-1 p-6 overflow-y-auto">{children}</div>
+
+                {/* Modal Footer */}
+                {footer && <div className="flex justify-end gap-3 p-6 border-t border-gray-200">{footer}</div>}
+            </div>
+        </div>
+    );
+};
+
+export default Modal;

--- a/pickleglass_web/components/Modal.tsx
+++ b/pickleglass_web/components/Modal.tsx
@@ -143,9 +143,9 @@ const Modal: React.FC<ModalProps> = ({ isOpen, onClose, title, children, footer,
                     /* Full screen on mobile */
                     w-full h-full
                     /* Modal style on larger screens */
-                    sm:w-[90%] sm:h-auto sm:max-h-[90vh] sm:rounded-lg sm:shadow-xl
-                    md:w-[85%] md:max-h-[85vh]
-                    lg:w-[80%] lg:max-h-[80vh]
+                    sm:w-[95%] sm:h-auto sm:max-h-[90vh] sm:rounded-lg sm:shadow-xl
+                    md:w-[90%] md:max-h-[90vh]
+                    lg:w-[85%] lg:max-h-[85vh]
                     /* Allow custom sizing via className prop */
                     ${className}`}
                 tabIndex={-1}

--- a/pickleglass_web/components/Modal.tsx
+++ b/pickleglass_web/components/Modal.tsx
@@ -168,7 +168,7 @@ const Modal: React.FC<ModalProps> = ({ isOpen, onClose, title, children, footer,
                 </div>
 
                 {/* Modal Content */}
-                <div className="flex-1 p-4 sm:p-6 overflow-y-auto">{children}</div>
+                <div className="flex-1 px-4 pb-4 sm:px-6 sm:pb-6 overflow-y-auto">{children}</div>
 
                 {/* Modal Footer */}
                 {footer && (

--- a/pickleglass_web/components/Modal.tsx
+++ b/pickleglass_web/components/Modal.tsx
@@ -68,7 +68,7 @@ const Modal: React.FC<ModalProps> = ({ isOpen, onClose, title, children, footer,
             document.removeEventListener('keydown', handleKeyDown);
             document.body.style.overflow = 'unset';
         };
-    }, [isOpen, onClose]);
+    }, [isOpen, onClose, handleTabKey]);
 
     // Handle click outside modal
     const handleOverlayClick = (event: React.MouseEvent<HTMLDivElement>) => {


### PR DESCRIPTION
## Summary of Changes

Improved preset modal viewing and editing by changing bottom text area to responsive modal-based editor.

The main idea is to create a dedicated, full-featured editing experience that:
1.  Users can browse presets in the grid view, then open a dedicated editor when they want to make changes
2.  The modal gives more space, better controls, and a focused editing experience
3.  Double-click to edit, with proper save/cancel flows and unsaved changes protection


## Related Issue

- Closes #159
