### PR TITLE
Fix duplicate transcript lines for local Whisper STT

### DIFF
--- a/src/features/listen/stt/sttService.js
+++ b/src/features/listen/stt/sttService.js
@@ -192,14 +192,6 @@ class SttService {
                     
                     if (!isNoise && finalText.length > 2) {
                         this.debounceMyCompletion(finalText);
-                        
-                        this.sendToRenderer('stt-update', {
-                            speaker: 'Me',
-                            text: finalText,
-                            isPartial: false,
-                            isFinal: true,
-                            timestamp: Date.now(),
-                        });
                     } else {
                         console.log(`[Whisper-Me] Filtered noise: "${finalText}"`);
                     }
@@ -334,14 +326,6 @@ class SttService {
                     // Only process if it's not noise, not a false positive, and has meaningful content
                     if (!isNoise && finalText.length > 2) {
                         this.debounceTheirCompletion(finalText);
-                        
-                        this.sendToRenderer('stt-update', {
-                            speaker: 'Them',
-                            text: finalText,
-                            isPartial: false,
-                            isFinal: true,
-                            timestamp: Date.now(),
-                        });
                     } else {
                         console.log(`[Whisper-Them] Filtered noise: "${finalText}"`);
                     }


### PR DESCRIPTION
## What
For the `whisper` provider branch of `handleMyMessage`/`handleTheirMessage` in `sttService.js`, every transcription was being sent to the renderer **twice**: once immediately via `sendToRenderer('stt-update', ...)`, and again ~2 seconds later when the debounce timer (`debounceMyCompletion`/`debounceTheirCompletion`) fires and calls `flushMyCompletion`/`flushTheirCompletion`, which also sends `'stt-update'`.

Every line spoken while using local Whisper STT shows up twice in the Listen panel.

## Why
The immediate `sendToRenderer` call duplicates what the debounce/flush path already does. Other STT providers in this file (Gemini, Deepgram) don't have this extra immediate send — only the whisper branch does.

## Fix
Removed the redundant immediate `sendToRenderer` calls in both the `Me` and `Them` whisper handlers, leaving the debounce path as the single source of truth — consistent with how the other providers already behave in this file.

## Testing
Verified locally with the Whisper (local) STT provider active: each spoken utterance now appears exactly once in the Listen transcript instead of twice.