### PR TITLE
Fix multi-byte UTF-8 corruption in streaming Ask responses

### DIFF
--- a/src/features/ask/askService.js
+++ b/src/features/ask/askService.js
@@ -370,6 +370,7 @@ class AskService {
     async _processStream(reader, askWin, sessionId, signal) {
         const decoder = new TextDecoder();
         let fullResponse = '';
+        let lineBuffer = '';
 
         try {
             this.state.isLoading = false;
@@ -379,14 +380,23 @@ class AskService {
                 const { done, value } = await reader.read();
                 if (done) break;
 
-                const chunk = decoder.decode(value);
-                const lines = chunk.split('\n').filter(line => line.trim() !== '');
+                // { stream: true } tells TextDecoder to hold back any incomplete
+                // multi-byte UTF-8 sequence at the chunk boundary instead of mangling it
+                // (critical for Cyrillic/other multi-byte text split across network chunks).
+                lineBuffer += decoder.decode(value, { stream: true });
+
+                // SSE lines can also be split across chunk boundaries — only process
+                // complete lines (ending in \n) and carry any trailing partial line over
+                // to be prefixed onto the next chunk.
+                const lines = lineBuffer.split('\n');
+                lineBuffer = lines.pop() || '';
 
                 for (const line of lines) {
+                    if (line.trim() === '') continue;
                     if (line.startsWith('data: ')) {
                         const data = line.substring(6);
                         if (data === '[DONE]') {
-                            return; 
+                            return;
                         }
                         try {
                             const json = JSON.parse(data);


### PR DESCRIPTION
## What
`askService.js`'s `_processStream` reads the streaming response body chunk-by-chunk and calls `chunk.split('\n')` directly on each decoded chunk to find SSE lines.

Two related bugs:
1. **Multi-byte UTF-8 corruption**: `TextDecoder.decode()` was called without `{ stream: true }`, so a multi-byte UTF-8 character (e.g. Cyrillic, CJK, emoji) split across two network chunk boundaries gets decoded incorrectly — each half is decoded independently instead of being buffered until a full character is available, producing garbled/replacement characters (`�`) in streamed output.
2. **SSE line-splitting across chunks**: a single SSE `data: ...` line isn't guaranteed to arrive in one chunk. Splitting each chunk on `\n` independently (instead of maintaining a persistent line buffer across chunks) can silently drop or merge lines whenever a line boundary doesn't line up with a chunk boundary.

Users streaming Ask responses in any non-ASCII-heavy language (Russian, Chinese, Japanese, etc.) intermittently see corrupted characters mid-response, and occasionally a line gets dropped entirely.

## Fix
- Added a persistent `lineBuffer` that accumulates decoded text across chunks and only processes complete lines (splitting on the last `\n`), carrying any trailing partial line over to the next chunk.
- Changed `decoder.decode(value)` to `decoder.decode(value, { stream: true })`, which tells `TextDecoder` to hold back a trailing incomplete multi-byte sequence and prepend it to the next `decode()` call instead of emitting a corrupted character immediately.

## Testing
Verified locally with a Russian-language conversation (`OPENAI_TRANSCRIBE_LANG=ru` / Russian prompts) streamed through Ask: previously-frequent `�` corruption in streamed responses no longer occurs, and long responses no longer show dropped/merged lines.